### PR TITLE
Implement support for '(quote ())' in the parser

### DIFF
--- a/lib/list.rb
+++ b/lib/list.rb
@@ -6,12 +6,8 @@ class List
   def evaluate(env)
     function, *arguments = array
     operation = function.symbol
-    if operation == :quote
-      arguments.first
-    else
-      first_argument, *other_arguments = arguments.map { |a| a.evaluate(env) }
-      first_argument.send(operation, *other_arguments)
-    end
+    first_argument, *other_arguments = arguments.map { |a| a.evaluate(env) }
+    first_argument.send(operation, *other_arguments)
   end
 
   def car

--- a/lib/list.rb
+++ b/lib/list.rb
@@ -4,10 +4,14 @@ class List
   end
 
   def evaluate(env)
-    function, *arguments = array
-    operation = function.symbol
-    first_argument, *other_arguments = arguments.map { |a| a.evaluate(env) }
-    first_argument.send(operation, *other_arguments)
+    if @array.empty?
+      self
+    else
+      function, *arguments = array
+      operation = function.symbol
+      first_argument, *other_arguments = arguments.map { |a| a.evaluate(env) }
+      first_argument.send(operation, *other_arguments)
+    end
   end
 
   def car

--- a/lib/scheme.treetop
+++ b/lib/scheme.treetop
@@ -1,6 +1,6 @@
 grammar Scheme
   rule sexp
-    atom / list
+    atom / quoted_null_list / list
   end
 
   rule list
@@ -16,6 +16,14 @@ grammar Scheme
     [^\s()]+ {
       def to_ast
         Atom.new(text_value.to_sym)
+      end
+    }
+  end
+
+  rule quoted_null_list
+    '(quote ())' {
+      def to_ast
+        List.new
       end
     }
   end


### PR DESCRIPTION
In the last book club meeting we opted to implement support '(quote ())' in evaluate but we were aware that we could have picked the alternative approach of implementing it the parser.

I thought it would be interesting to look at what an alternative implementation might look like.

This implementation is perhaps a closer match for the description of '(quote ())' given in the Little Schemer page 9, where it is introduced which suggests that '(quote ())' is just alternative notation for '()' (in the footnotes).
