### PR TITLE
Tidy up after meeting 5

### DIFF
--- a/lib/atom.rb
+++ b/lib/atom.rb
@@ -9,7 +9,9 @@ class Atom
   FALSE = new(:'#f').freeze
 
   def evaluate(env)
-    if symbol == :else
+    if self == TRUE || self == FALSE
+      self
+    elsif symbol == :else
       TRUE
     else
       env[symbol]

--- a/lib/list.rb
+++ b/lib/list.rb
@@ -11,7 +11,7 @@ class List
       expression = function.cdr.cdr.car
       parameter = function.cdr.car.car
 
-      Lambda.new(parameter, expression).evaluate(env, arguments.first.evaluate(env))
+      Lambda.new(parameter, expression).evaluate(env, arguments.first)
     else
       operation = function.symbol
       if env.key?(operation)


### PR DESCRIPTION
This pull request fixes a couple of little things that we let slip at the end of meeting 5 i.e.
- It fixes the immediate evaluation of lambdas that we had broken when removing duplication
- It fixes the `describe (lat? l)` specs by ensuring that `#t` and `#f` evaluate as expected
