### PR TITLE
Switch to Ruby booleans for query methods

### DIFF
--- a/lib/atom.rb
+++ b/lib/atom.rb
@@ -8,14 +8,10 @@ class Atom
   TRUE = new(:'#t').freeze
   FALSE = new(:'#f').freeze
 
-  def self.from_boolean(boolean)
-    boolean ? TRUE : FALSE
-  end
-
   def evaluate(env)
     if self == TRUE || self == FALSE
       self
-    elsif number? == TRUE
+    elsif number?
       self
     else
       env.fetch(symbol)
@@ -23,17 +19,17 @@ class Atom
   end
 
   def atom?
-    TRUE
+    true
   end
 
   def number?
-    Atom.from_boolean(symbol =~ /^\d+$/)
+    symbol =~ /^\d+$/ ? true : false
   end
 
   def eq?(other)
-    raise if [self, other].any? { |atom| atom.number? == TRUE }
+    raise if [self, other].any?(&:number?)
 
-    Atom.from_boolean(self == other)
+    self == other
   end
 
   def cons(list)
@@ -54,12 +50,12 @@ class Atom
 
   def sub1
     Atom.new((integer - 1).to_s).tap do |result|
-      raise unless result.number? == TRUE
+      raise unless result.number?
     end
   end
 
   def zero?
-    Atom.from_boolean(integer.zero?)
+    integer.zero?
   end
 
   private

--- a/lib/evaluator.rb
+++ b/lib/evaluator.rb
@@ -1,11 +1,21 @@
 class Evaluator
+  def self.to_scheme_value(value)
+    if value == true
+      Atom::TRUE
+    elsif value == false
+      Atom::FALSE
+    else
+      value
+    end
+  end
+
   class Keyword
     def initialize(&block)
       @block = block
     end
 
     def apply(env, arguments)
-      @block.call(env, arguments)
+      Evaluator.to_scheme_value(@block.call(env, arguments))
     end
   end
 
@@ -16,7 +26,7 @@ class Evaluator
 
     def apply(env, arguments)
       first_argument, *other_arguments = arguments.map { |a| a.evaluate(env) }
-      first_argument.send(@operation, *other_arguments)
+      Evaluator.to_scheme_value(first_argument.send(@operation, *other_arguments))
     end
   end
 

--- a/lib/list.rb
+++ b/lib/list.rb
@@ -29,11 +29,11 @@ class List
   end
 
   def null?
-    Atom.from_boolean(array.empty?)
+    array.empty?
   end
 
   def atom?
-    Atom::FALSE
+    false
   end
 
   def ==(other)

--- a/spec/support/matchers/syntax_matchers.rb
+++ b/spec/support/matchers/syntax_matchers.rb
@@ -47,7 +47,7 @@ module SyntaxMatchers
   matcher :be_a_tup do
     match do |string|
       s_expression = parse_s_expression(string)
-      s_expression.array.all? { |s_expression| s_expression.is_a?(Atom) && s_expression.number? == Atom::TRUE }
+      s_expression.array.all? { |s_expression| s_expression.is_a?(Atom) && s_expression.number? }
     end
   end
 end


### PR DESCRIPTION
Because we keep getting confused about whether these methods return Ruby or Scheme booleans and we have to work harder to make use of the Scheme booleans in our Ruby code.

This would resolve issue #10
