### PR TITLE
White space tolerance

### DIFF
--- a/lib/scheme.treetop
+++ b/lib/scheme.treetop
@@ -4,7 +4,7 @@ grammar Scheme
   end
 
   rule list
-    '(' sexps:(sexp ' '?)* ')' {
+    space '(' sexps:(sexp space)* ')' space {
       def to_ast
         list_contents = sexps.elements.map{|element| element.sexp.to_ast }
         List.new(*list_contents)
@@ -13,10 +13,14 @@ grammar Scheme
   end
 
   rule atom
-    [^\s()]+ {
+    space [^\s()]+ space {
       def to_ast
-        Atom.new(text_value.to_sym)
+        Atom.new(text_value.strip.to_sym)
       end
     }
+  end
+
+  rule space
+    [\s]*
   end
 end

--- a/spec/whitespace_in_scheme_spec.rb
+++ b/spec/whitespace_in_scheme_spec.rb
@@ -1,0 +1,29 @@
+describe 'a little Scheme' do
+  context 'despite what the book says, can cope with extra whitespace to make programs more reable' do
+    include SyntaxMatchers
+
+    specify { expect(' atom ').to be_an_atom }
+    specify { expect(' 1492 ').to be_an_atom }
+
+    describe '(atom  otheratom) ' do
+      it { is_expected.to be_a_list }
+      it { is_expected.to contain_the_s_expressions 'atom', 'otheratom' }
+    end
+
+    describe ' (atom) ' do
+      it { is_expected.to be_a_list }
+      it { is_expected.to contain_the_s_expressions 'atom' }
+    end
+
+    describe '
+(
+ a
+ b
+ c
+)
+             ' do
+      it { is_expected.to be_a_list }
+      it { is_expected.to contain_the_s_expressions 'a', 'b', 'c' }
+    end
+  end
+end

--- a/spec/whitespace_in_scheme_spec.rb
+++ b/spec/whitespace_in_scheme_spec.rb
@@ -25,5 +25,25 @@ describe 'a little Scheme' do
       it { is_expected.to be_a_list }
       it { is_expected.to contain_the_s_expressions 'a', 'b', 'c' }
     end
+
+    describe '
+(
+  (
+    (how)
+    are
+  )
+  (
+    (you)
+    (
+      doing
+      so
+    )
+  )
+  far
+)
+             ' do
+      it { is_expected.to be_a_list }
+      it { is_expected.to contain_the_s_expressions '((how) are)', '((you) (doing so))', 'far' }
+    end
   end
 end


### PR DESCRIPTION
This should make the parser more tolerant of whitespace.  I don't know that this is the cleanest solution, I guess there's a better one, but with rubyforge having gone away the treetop docs are AWOL :(

This should address #11.
