### PR TITLE
Ruby booleans all the way

### DIFF
--- a/lib/atom.rb
+++ b/lib/atom.rb
@@ -27,7 +27,7 @@ class Atom
   end
 
   def number?
-    Atom.from_boolean(symbol =~ /^\d+$/)
+    !!(symbol =~ /^\d+$/)
   end
 
   def eq?(other)

--- a/lib/atom.rb
+++ b/lib/atom.rb
@@ -15,7 +15,7 @@ class Atom
   def evaluate(env)
     if self == TRUE || self == FALSE
       self
-    elsif number? == TRUE
+    elsif number?
       self
     else
       env.fetch(symbol)
@@ -23,7 +23,7 @@ class Atom
   end
 
   def atom?
-    TRUE
+    true
   end
 
   def number?
@@ -31,9 +31,9 @@ class Atom
   end
 
   def eq?(other)
-    raise if [self, other].any? { |atom| atom.number? == TRUE }
+    raise if [self, other].any? &:number?
 
-    Atom.from_boolean(self == other)
+    self == other
   end
 
   def cons(list)
@@ -54,12 +54,12 @@ class Atom
 
   def sub1
     Atom.new((integer - 1).to_s).tap do |result|
-      raise unless result.number? == TRUE
+      raise unless result.number?
     end
   end
 
   def zero?
-    Atom.from_boolean(integer.zero?)
+    integer.zero?
   end
 
   private

--- a/lib/evaluator.rb
+++ b/lib/evaluator.rb
@@ -20,6 +20,12 @@ class Evaluator
     end
   end
 
+  class Predicate < Primitive
+    def apply(env, arguments)
+      Atom.from_boolean(super)
+    end
+  end
+
   KEYWORDS = {
     lambda: Keyword.new { |env, arguments|
       parameters = arguments.first.array
@@ -45,11 +51,11 @@ class Evaluator
     car: Primitive.new(:car),
     cdr: Primitive.new(:cdr),
     cons: Primitive.new(:cons),
-    null?: Primitive.new(:null?),
-    atom?: Primitive.new(:atom?),
-    eq?: Primitive.new(:eq?),
-    zero?: Primitive.new(:zero?),
-    number?: Primitive.new(:number?),
+    null?: Predicate.new(:null?),
+    atom?: Predicate.new(:atom?),
+    eq?: Predicate.new(:eq?),
+    zero?: Predicate.new(:zero?),
+    number?: Predicate.new(:number?),
     add1: Primitive.new(:add1),
     sub1: Primitive.new(:sub1)
   }

--- a/lib/evaluator.rb
+++ b/lib/evaluator.rb
@@ -22,7 +22,9 @@ class Evaluator
 
   class Predicate < Primitive
     def apply(env, arguments)
-      Atom.from_boolean(super)
+      value = super
+      raise "Predicate #{@operation} called, but received non boolean value '#{value.inspect}'" unless [TrueClass, FalseClass].include? value.class
+      Atom.from_boolean(value)
     end
   end
 

--- a/lib/list.rb
+++ b/lib/list.rb
@@ -29,11 +29,11 @@ class List
   end
 
   def null?
-    Atom.from_boolean(array.empty?)
+    array.empty?
   end
 
   def atom?
-    Atom::FALSE
+    false
   end
 
   def ==(other)

--- a/spec/support/matchers/syntax_matchers.rb
+++ b/spec/support/matchers/syntax_matchers.rb
@@ -40,14 +40,14 @@ module SyntaxMatchers
   matcher :be_a_number do
     match do |string|
       s_expression = parse_s_expression(string)
-      s_expression.number? == Atom::TRUE
+      s_expression.number?
     end
   end
 
   matcher :be_a_tup do
     match do |string|
       s_expression = parse_s_expression(string)
-      s_expression.array.all? { |s_expression| s_expression.is_a?(Atom) && s_expression.number? == Atom::TRUE }
+      s_expression.array.all? { |s_expression| s_expression.is_a?(Atom) && s_expression.number? }
     end
   end
 end


### PR DESCRIPTION
Make all the Atom#XXX? and List#XXX? methods return a ruby boolean and deal with translation in the evaluator.

Not entirely sure about the final commit 2054120, but we'll see.

This addresses #10.
